### PR TITLE
chore: bump version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "css-var-kit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85"
 homepage = "https://github.com/jo16oh/css-var-kit"

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@css-var-kit/cli-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "css-var-kit native binary for macOS ARM64",
   "license": "MIT",
   "repository": {

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@css-var-kit/cli-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "css-var-kit native binary for macOS x64",
   "license": "MIT",
   "repository": {

--- a/packages/cli-linux-arm64/package.json
+++ b/packages/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@css-var-kit/cli-linux-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "css-var-kit native binary for Linux ARM64",
   "license": "MIT",
   "repository": {

--- a/packages/cli-linux-x64/package.json
+++ b/packages/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@css-var-kit/cli-linux-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "css-var-kit native binary for Linux x64",
   "license": "MIT",
   "repository": {

--- a/packages/cli-win32-x64/package.json
+++ b/packages/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@css-var-kit/cli-win32-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "css-var-kit native binary for Windows x64",
   "license": "MIT",
   "repository": {

--- a/packages/css-var-kit/package.json
+++ b/packages/css-var-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-var-kit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple, lightweight toolkit to help build design systems using raw CSS.",
   "license": "MIT",
   "repository": {
@@ -12,10 +12,10 @@
   },
   "files": ["bin/css-var-kit.js"],
   "optionalDependencies": {
-    "@css-var-kit/cli-darwin-arm64": "0.1.0",
-    "@css-var-kit/cli-darwin-x64": "0.1.0",
-    "@css-var-kit/cli-linux-x64": "0.1.0",
-    "@css-var-kit/cli-linux-arm64": "0.1.0",
-    "@css-var-kit/cli-win32-x64": "0.1.0"
+    "@css-var-kit/cli-darwin-arm64": "0.1.1",
+    "@css-var-kit/cli-darwin-x64": "0.1.1",
+    "@css-var-kit/cli-linux-x64": "0.1.1",
+    "@css-var-kit/cli-linux-arm64": "0.1.1",
+    "@css-var-kit/cli-win32-x64": "0.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bump version to v0.1.1 across Cargo.toml and all npm package.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)