### PR TITLE
fix: sync cli binary versions and silence workspace warnings

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,8 +10,9 @@ bump-version level:
     version=$(node -p "require('./packages/css-var-kit/package.json').version")
 
     just sync-optional-deps
+    pnpm install --lockfile-only
 
-    git add packages/*/package.json Cargo.toml Cargo.lock crates/*/Cargo.toml
+    git add packages/*/package.json Cargo.toml Cargo.lock crates/*/Cargo.toml pnpm-lock.yaml
     git commit -m "chore: bump version to $version"
     git tag "v$version"
 

--- a/justfile
+++ b/justfile
@@ -1,15 +1,30 @@
 bump-version level:
     #!/usr/bin/env sh
-    pnpm bumpp --recursive --release {{level}} --yes --no-commit --no-tag --no-push & \
-    cargo set-version --bump {{level}} --workspace & \
+    for dir in packages/css-var-kit packages/vscode packages/cli-darwin-arm64 packages/cli-darwin-x64 packages/cli-linux-arm64 packages/cli-linux-x64 packages/cli-win32-x64; do
+      (cd "$dir" && pnpm bumpp --release {{level}} --yes --no-commit --no-tag --no-push) &
+    done
+    cargo set-version --bump {{level}} --workspace &
     wait
     cargo generate-lockfile
 
     version=$(node -p "require('./packages/css-var-kit/package.json').version")
 
+    just sync-optional-deps
+
     git add packages/*/package.json Cargo.toml Cargo.lock crates/*/Cargo.toml
     git commit -m "chore: bump version to $version"
     git tag "v$version"
+
+sync-optional-deps:
+    @node -e "\
+      const fs = require('fs');\
+      const p = './packages/css-var-kit/package.json';\
+      const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));\
+      for (const k of Object.keys(pkg.optionalDependencies || {})) {\
+        pkg.optionalDependencies[k] = pkg.version;\
+      }\
+      fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');\
+    "
 
 gen-value-kind-set:
     @pnpm tsx scripts/gen-value-kind-set/main.ts crates/css-var-kit/generated/value_kind_set.rs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,16 +30,6 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
-  packages/cli-darwin-arm64: {}
-
-  packages/cli-darwin-x64: {}
-
-  packages/cli-linux-arm64: {}
-
-  packages/cli-linux-x64: {}
-
-  packages/cli-win32-x64: {}
-
   packages/css-var-kit:
     optionalDependencies:
       '@css-var-kit/cli-darwin-arm64':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
-  - packages/*
+  - packages/css-var-kit
+  - packages/vscode
   - scripts/gen-value-kind-set


### PR DESCRIPTION
## Summary
- Fix stale `optionalDependencies` in `css-var-kit` that pinned cli binaries to `0.1.3` even though current releases are `0.2.x`, causing users to install outdated binaries
- Exclude `packages/cli-*` from the pnpm workspace so the native-binary packages no longer emit `Unsupported platform` warnings on every `pnpm install`
- Update `bump-version` just task to bump each package individually (since `bumpp --recursive` reads `pnpm-workspace.yaml`) and add a new `sync-optional-deps` task that rewrites `optionalDependencies` to match `version` after each bump

## Test plan
- [x] `pnpm install` no longer prints `Unsupported platform` warnings
- [x] `just bump-version patch` bumps all cli packages and syncs `optionalDependencies` (verified in df235af)
- [ ] After merge, release workflow publishes `css-var-kit@0.2.5` with matching `@css-var-kit/cli-*@0.2.5` in `optionalDependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)