### PR TITLE
fix: exclude css-var-kit from pnpm workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,6 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
-  packages/css-var-kit: {}
-
   packages/vscode:
     dependencies:
       vscode-languageclient:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
-  - packages/css-var-kit
   - packages/vscode
   - scripts/gen-value-kind-set


### PR DESCRIPTION
## Summary
- Exclude `packages/css-var-kit` from the pnpm workspace alongside `packages/cli-*`
- Fixes `ERR_PNPM_OUTDATED_LOCKFILE` in the release workflow caused by a chicken-and-egg problem: during `just bump-version`, `pnpm install --lockfile-only` tries to resolve `@css-var-kit/cli-*@<new version>` which is not yet published, so pnpm omits them from the lockfile; then CI checks the bumped manifest against the stale lockfile and fails

`css-var-kit` is a publish-only wrapper (bin entry + `optionalDependencies`). Nothing in the workspace consumes it, so excluding it is safe. `just bump-version` already runs `bumpp` in each package directory individually, so workspace membership is not required for bumping.

## Recovery steps after merge
The `v0.2.5` tag will need to be re-pointed at the new main HEAD so the release workflow re-runs against the fixed lockfile:
```sh
git tag -d v0.2.5
git push --delete origin v0.2.5
git tag v0.2.5 <new-main-HEAD>
git push origin v0.2.5
```
The npm publish jobs are guarded by `npm view`, so already-published 0.2.5 packages will be skipped; only `publish-vscode` will actually run.

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally
- [ ] Release workflow succeeds after re-tagging v0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)