### PR TITLE
feat(vscode): add cvk.lsp.log setting for stderr and file logging

### DIFF
--- a/crates/zed-extension/README.md
+++ b/crates/zed-extension/README.md
@@ -2,8 +2,6 @@
 
 Zed extension that provides type-aware CSS variable completion, diagnostics, rename, and go-to-definition by wrapping the [`cvk`](https://github.com/jo16oh/css-var-kit) language server.
 
-Supports CSS, SCSS, HTML, Vue, Svelte, and Astro.
-
 ## Installation
 
 Install the **css-var-kit** extension from Zed's Extensions panel.
@@ -16,7 +14,7 @@ The extension resolves the `cvk` binary in this order:
 
 ## Configuration
 
-Configuration mirrors the VS Code extension. If a `cvk.json` or `cvk.jsonc` exists in the workspace root, it takes precedence and Zed settings for the language server are ignored.
+If a `cvk.json` or `cvk.jsonc` exists in the workspace root, it takes precedence and `initialization_options` are ignored.
 
 Example `settings.json`:
 
@@ -25,12 +23,12 @@ Example `settings.json`:
   "lsp": {
     "css-var-kit": {
       "binary": {
-        "path": "/usr/local/bin/cvk"
+        "path": "/usr/local/bin/cvk",
+        "args": ["lsp", "--log"]
       },
       "initialization_options": {
         "rootDir": ".",
         "lookupFiles": ["**/*.css"],
-        "excludeFiles": [],
         "rules": {
           "no-undefined-variable-use": "error",
           "no-variable-type-mismatch": "error",
@@ -38,7 +36,7 @@ Example `settings.json`:
           "enforce-variable-use": "off"
         },
         "lsp": {
-          "logFile": null
+          "logFile": "/path/to/cvk.log"
         }
       }
     }
@@ -47,13 +45,3 @@ Example `settings.json`:
 ```
 
 See [docs/config.md](https://github.com/jo16oh/css-var-kit/blob/main/docs/config.md) for the full set of options.
-
-## Development
-
-```sh
-rustup target add wasm32-wasip2
-cd crates/zed-extension
-cargo build --release --target wasm32-wasip2
-```
-
-In Zed: `extensions` panel → `Install Dev Extension` → select `crates/zed-extension/`.

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -29,16 +29,17 @@ If your project has a `cvk.json` (or `cvk.jsonc`), the extension uses it directl
 
 If no config file exists, you can configure rules via VS Code settings:
 
-| Setting                                      | Default        | Description                       |
-| -------------------------------------------- | -------------- | --------------------------------- |
-| `cvk.path`                                   | `null`         | Path to the `cvk` binary          |
-| `cvk.rootDir`                                | `"."`          | Root directory for analysis       |
-| `cvk.lookupFiles`                            | `["**/*.css"]` | Glob patterns for CSS files       |
-| `cvk.rules.noUndefinedVariableUse`           | `"error"`      | Undefined variable usage          |
-| `cvk.rules.noVariableTypeMismatch`           | `"error"`      | Variable type mismatch            |
-| `cvk.rules.noInconsistentVariableDefinition` | `"error"`      | Inconsistent variable definitions |
-| `cvk.rules.enforceVariableUse`               | `"off"`        | Enforce CSS variable usage        |
-| `cvk.lsp.logFile`                            | `null`         | LSP log file path                 |
+| Setting                                      | Default        | Description                            |
+| -------------------------------------------- | -------------- | -------------------------------------- |
+| `cvk.path`                                   | `null`         | Path to the `cvk` binary               |
+| `cvk.rootDir`                                | `"."`          | Root directory for analysis            |
+| `cvk.lookupFiles`                            | `["**/*.css"]` | Glob patterns for CSS files            |
+| `cvk.rules.noUndefinedVariableUse`           | `"error"`      | Undefined variable usage               |
+| `cvk.rules.noVariableTypeMismatch`           | `"error"`      | Variable type mismatch                 |
+| `cvk.rules.noInconsistentVariableDefinition` | `"error"`      | Inconsistent variable definitions      |
+| `cvk.rules.enforceVariableUse`               | `"off"`        | Enforce CSS variable usage             |
+| `cvk.lsp.log`                                | `false`        | `true` to enable LSP logging to stderr |
+| `cvk.lsp.logFile`                            | `null`         | LSP log file path                      |
 
 > When `cvk.json` exists, it takes full precedence and VS Code settings are ignored.
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -101,6 +101,11 @@
           "default": "off",
           "markdownDescription": "Enforce CSS variable usage. Set to `\"error\"`, `\"warn\"`, `\"off\"`, or an object with detailed config."
         },
+        "cvk.lsp.log": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Set to `true` to enable LSP logging to stderr."
+        },
         "cvk.lsp.logFile": {
           "type": [
             "string",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -20,9 +20,10 @@ async function startClient(): Promise<void> {
     return;
   }
 
+  const log = workspace.getConfiguration("cvk").get<boolean>("lsp.log");
   const serverOptions: ServerOptions = {
     command: binary,
-    args: ["lsp"],
+    args: ["lsp", ...(log ? ["--log"] : [])],
   };
 
   const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
- Setting cvk.lsp.log: true passes the --log flag and outputs logs to stderr.

- cvk.lsp.logFile: "path" remains as the existing behavior (set in initializationOptions.lsp.logFile).

- Previously, it was not possible to set stderr logs because args: ["lsp"] in the VSCode extension was fixed.