### PR TITLE
fix(lsp): preserve opened buffers across config reload

### DIFF
--- a/crates/css-var-kit/src/commands/lsp.rs
+++ b/crates/css-var-kit/src/commands/lsp.rs
@@ -365,7 +365,13 @@ impl Server<'_> {
         match Config::load_for_lsp(&self.lsp_root_dir, self.init_options.clone()) {
             Ok(new_config) => {
                 self.config = new_config;
-                self.source_cache = load_all_sources(&self.config);
+                let mut source_cache = load_all_sources(&self.config);
+                for (uri, text) in &self.opened_documents {
+                    if let Some(rel_path) = self.uri_to_rel_path(uri) {
+                        source_cache.insert(Rc::<Path>::from(rel_path), OwnedStr::from(text));
+                    }
+                }
+                self.source_cache = source_cache;
                 self.parse_cache = build_parse_cache(&self.source_cache);
                 self.searcher = build_searcher(&self.parse_cache, &self.config);
                 self.log("config reloaded");


### PR DESCRIPTION
## Summary

- `reload_config` was rebuilding `source_cache` from disk via `load_all_sources`, wiping the in-memory text of any document the client had opened with `didOpen`.
- When the file watcher delivered a `cvk.json` modification event between a `didOpen` and a subsequent request (rename/diagnostics/etc.), the searcher was rebuilt against stale disk content and missed unsaved edits.
- After loading sources from disk, re-apply `opened_documents` on top of the cache before rebuilding `parse_cache` and `searcher` — same invariant that `update_source_cache_from_disk` already enforces via its `is_open` skip.

## Background

Surfaced as flakiness in `rename_vue_defined_variable` (in `tests/lsp_html_like.rs`). The test:

1. Copies fixtures to a tempdir, then `fs::write`s `cvk.json` with `lookupFiles`.
2. Spawns the LSP — which starts a `notify`-based recursive watcher.
3. `didOpen`s `Component.vue` with custom buffer text referencing `--vue-color`.
4. Requests rename of `--vue-color` from `Tokens.vue`.

Under parallel test load, FSEvents would deliver the recent `cvk.json` write to the watcher mid-test, triggering `reload_config()` after `didOpen` had populated the buffer. `load_all_sources` then re-read `Component.vue` from disk (original fixture, no `--vue-color`), and the rename returned no edits for `Component.vue`.

Single-test or single-threaded runs always passed because the timing window didn't open up.

## Test plan

- [x] Run full `cargo test` 10× — all pass (was previously failing ~40% of the time).
- [x] Run `rename_vue_defined_variable` in isolation — still passes.
- [x] `cargo fmt` / `cargo clippy` clean (enforced by pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)