### PR TITLE
fix(lsp): watch scss and html files

### DIFF
--- a/crates/css-var-kit/src/commands/lint.rs
+++ b/crates/css-var-kit/src/commands/lint.rs
@@ -5,6 +5,7 @@ use std::process;
 use std::rc::Rc;
 
 use crate::config::{Config, GlobFilter};
+use crate::file_kinds::{is_html_like_extension, is_supported_source_extension};
 use crate::owned_types::OwnedStr;
 use crate::parser;
 use crate::parser::ParseResult;
@@ -13,8 +14,6 @@ use crate::searcher::conditions::non_custom_properties::NonCustomProperties;
 use crate::searcher::conditions::variable_definitions::VariableDefinitions;
 use crate::searcher::conditions::variable_usages::VariableUsages;
 use crate::searcher::{SearchResult, Searcher};
-
-const HTML_LIKE_EXTENSIONS: &[&str] = &["html", "vue", "svelte", "astro"];
 
 pub fn run(config: &Config) {
     let css_files = collect_source_files(config.root_dir.as_path(), &config.include);
@@ -157,7 +156,7 @@ fn collect_include_recursive(
 fn is_supported_extension(path: &Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
-        .is_some_and(|ext| matches!(ext, "css" | "scss") || HTML_LIKE_EXTENSIONS.contains(&ext))
+        .is_some_and(is_supported_source_extension)
 }
 
 fn collect_source_files_recursive(
@@ -188,7 +187,7 @@ fn collect_source_files_recursive(
 pub fn parse_file(source: &OwnedStr, path: &Path) -> Vec<ParseResult> {
     let file_path: Rc<Path> = Rc::from(path);
     match path.extension().and_then(|e| e.to_str()) {
-        Some(ext) if HTML_LIKE_EXTENSIONS.contains(&ext) => {
+        Some(ext) if is_html_like_extension(ext) => {
             parser::html_like::parse_html_like(source, &file_path)
         }
         _ => vec![parser::css::parse(source, &file_path)],

--- a/crates/css-var-kit/src/commands/lsp.rs
+++ b/crates/css-var-kit/src/commands/lsp.rs
@@ -28,6 +28,7 @@ use lsp_types::{
 
 use crate::commands::lint;
 use crate::config::{Config, RawConfig};
+use crate::file_kinds::is_config_filename;
 use crate::owned_types::OwnedStr;
 use crate::parser::ParseResult;
 use crate::searcher::Searcher;
@@ -399,10 +400,9 @@ impl Server<'_> {
 }
 
 fn is_config_file(path: &Path) -> bool {
-    matches!(
-        path.file_name().and_then(|n| n.to_str()),
-        Some("cvk.json" | "cvk.jsonc")
-    )
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(is_config_filename)
 }
 
 fn build_searcher(parse_cache: &HashMap<Rc<Path>, Vec<ParseResult>>, config: &Config) -> Searcher {

--- a/crates/css-var-kit/src/commands/lsp/file_watcher.rs
+++ b/crates/css-var-kit/src/commands/lsp/file_watcher.rs
@@ -14,6 +14,8 @@ use lsp_types::{
 use notify::RecursiveMode;
 use notify_debouncer_full::{DebouncedEvent, new_debouncer};
 
+use crate::file_kinds::{is_config_filename, is_supported_source_extension, watched_glob_patterns};
+
 pub fn client_supports_watch(init_params: &InitializeParams) -> bool {
     init_params
         .capabilities
@@ -30,20 +32,13 @@ pub fn register_client_watcher(connection: &Connection) -> Result<(), Box<dyn Er
         method: DidChangeWatchedFiles::METHOD.to_owned(),
         register_options: Some(serde_json::to_value(
             DidChangeWatchedFilesRegistrationOptions {
-                watchers: [
-                    "**/*.css",
-                    "**/*.vue",
-                    "**/*.svelte",
-                    "**/*.astro",
-                    "**/cvk.json",
-                    "**/cvk.jsonc",
-                ]
-                .into_iter()
-                .map(|pattern| FileSystemWatcher {
-                    glob_pattern: GlobPattern::String(pattern.to_owned()),
-                    kind: None,
-                })
-                .collect(),
+                watchers: watched_glob_patterns()
+                    .into_iter()
+                    .map(|pattern| FileSystemWatcher {
+                        glob_pattern: GlobPattern::String(pattern),
+                        kind: None,
+                    })
+                    .collect(),
             },
         )?),
     };
@@ -66,18 +61,16 @@ pub fn start_server_watcher(root_dir: &Path) -> Result<Receiver<Vec<PathBuf>>, B
         None,
         move |events: Result<Vec<DebouncedEvent>, _>| {
             if let Ok(events) = events {
-                const WATCHED_EXTENSIONS: &[&str] = &["css", "vue", "svelte", "astro"];
-                const CONFIG_FILENAMES: &[&str] = &["cvk.json", "cvk.jsonc"];
                 let mut paths: Vec<PathBuf> = events
                     .iter()
                     .flat_map(|e| &e.paths)
                     .filter(|p| {
                         p.extension()
                             .and_then(|e| e.to_str())
-                            .is_some_and(|ext| WATCHED_EXTENSIONS.contains(&ext))
+                            .is_some_and(is_supported_source_extension)
                             || p.file_name()
                                 .and_then(|n| n.to_str())
-                                .is_some_and(|name| CONFIG_FILENAMES.contains(&name))
+                                .is_some_and(is_config_filename)
                     })
                     .cloned()
                     .collect();

--- a/crates/css-var-kit/src/config.rs
+++ b/crates/css-var-kit/src/config.rs
@@ -14,6 +14,7 @@ use crate::{
         file::{RawRules, SeverityToggle},
         rules::Rules,
     },
+    file_kinds::CONFIG_FILENAMES,
     rules::enforce_variable_use::config::RawEnforceVariableUse,
 };
 
@@ -310,7 +311,11 @@ fn resolve_file_args_to_patterns(args: &[String], cwd: &Path, root_dir: &Path) -
 }
 
 pub fn find_project_root(cwd: &Path) -> PathBuf {
-    let markers = ["cvk.json", "cvk.jsonc", "package.json", ".git"];
+    let markers: Vec<&str> = CONFIG_FILENAMES
+        .iter()
+        .copied()
+        .chain(["package.json", ".git"])
+        .collect();
 
     for marker in markers {
         let mut dir = cwd;

--- a/crates/css-var-kit/src/config/file.rs
+++ b/crates/css-var-kit/src/config/file.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde::de::{self, Deserializer};
 
 use super::ConfigError;
+use crate::file_kinds::CONFIG_FILENAMES;
 use crate::rules::Severity;
 use crate::rules::enforce_variable_use::config::RawEnforceVariableUse;
 
@@ -49,19 +50,16 @@ impl RawConfig {
     /// Searches for `cvk.json` or `cvk.jsonc` in `project_root`.
     /// Returns `Ok(Some(config))` if found, `Ok(None)` if no config file exists.
     pub fn load(project_root: &Path) -> Result<Option<Self>, ConfigError> {
-        let candidates = ["cvk.json", "cvk.jsonc"];
-
-        for name in candidates {
-            let path = project_root.join(name);
-            if let Ok(raw) = fs::read_to_string(&path) {
+        CONFIG_FILENAMES
+            .iter()
+            .map(|name| project_root.join(name))
+            .find_map(|path| fs::read_to_string(&path).ok().map(|raw| (path, raw)))
+            .map(|(path, raw)| {
                 let stripped = json_strip_comments::StripComments::new(raw.as_bytes());
-                return serde_json::from_reader(stripped)
-                    .map(Some)
-                    .map_err(|e| ConfigError::Parse { path, source: e });
-            }
-        }
-
-        Ok(None)
+                serde_json::from_reader(stripped)
+                    .map_err(|e| ConfigError::Parse { path, source: e })
+            })
+            .transpose()
     }
 
     pub(super) fn load_from(path: &Path) -> Result<Self, ConfigError> {

--- a/crates/css-var-kit/src/file_kinds.rs
+++ b/crates/css-var-kit/src/file_kinds.rs
@@ -1,0 +1,24 @@
+pub const CSS_EXTENSIONS: &[&str] = &["css", "scss"];
+pub const HTML_LIKE_EXTENSIONS: &[&str] = &["html", "vue", "svelte", "astro"];
+pub const CONFIG_FILENAMES: &[&str] = &["cvk.json", "cvk.jsonc"];
+
+pub fn is_supported_source_extension(ext: &str) -> bool {
+    CSS_EXTENSIONS.contains(&ext) || HTML_LIKE_EXTENSIONS.contains(&ext)
+}
+
+pub fn is_html_like_extension(ext: &str) -> bool {
+    HTML_LIKE_EXTENSIONS.contains(&ext)
+}
+
+pub fn is_config_filename(name: &str) -> bool {
+    CONFIG_FILENAMES.contains(&name)
+}
+
+pub fn watched_glob_patterns() -> Vec<String> {
+    CSS_EXTENSIONS
+        .iter()
+        .chain(HTML_LIKE_EXTENSIONS.iter())
+        .map(|ext| format!("**/*.{ext}"))
+        .chain(CONFIG_FILENAMES.iter().map(|name| format!("**/{name}")))
+        .collect()
+}

--- a/crates/css-var-kit/src/main.rs
+++ b/crates/css-var-kit/src/main.rs
@@ -3,6 +3,7 @@ mod color_value;
 mod commands;
 mod config;
 mod diagnostic_renderer;
+mod file_kinds;
 mod owned_types;
 mod parser;
 mod rules;


### PR DESCRIPTION
## Summary
- The LSP file watcher (both the client-side `workspace/didChangeWatchedFiles` registration and the server-side `notify` fallback) only listed `css`, `vue`, `svelte`, `astro`, so edits to `.scss` and `.html` files never triggered diagnostic refreshes — even though the linter/parser already fully support them and the Zed extension declares all six languages.
- Consolidated the previously-duplicated extension and config-filename literals into a new `file_kinds` module shared by `commands::lint`, `commands::lsp`, `commands::lsp::file_watcher`, and `config`, so the watched set can no longer drift from the linted set.

### Before / after
| List | Before | After |
| --- | --- | --- |
| Server-side `WATCHED_EXTENSIONS` | `css, vue, svelte, astro` | `css, scss, html, vue, svelte, astro` |
| Client-side glob patterns | `**/*.{css,vue,svelte,astro}` + `**/cvk.json{,c}` | `**/*.{css,scss,html,vue,svelte,astro}` + `**/cvk.json{,c}` |

### Deduplicated literals
- `["cvk.json", "cvk.jsonc"]` — was repeated in `config/file.rs`, `config.rs`, `commands/lsp.rs`, and twice in `file_watcher.rs`.
- `["html", "vue", "svelte", "astro"]` — was repeated in `commands/lint.rs` and `file_watcher.rs` (with `html` missing in the latter).
- `["css", "scss"]` — implied across `commands/lint.rs` and `file_watcher.rs` (with `scss` missing in the latter).

## Test plan
- [x] `cargo build -p css-var-kit`
- [x] `cargo test -p css-var-kit` (411 tests pass)
- [x] `cargo clippy -p css-var-kit --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)